### PR TITLE
znk/add latest

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,3 @@
+# pinsha (development version)
+
+* Initial version of pinsha

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,18 @@
+looks_like_sha <- function(sha) {
+  grepl("^[a-fA-F0-9]{40}$", sha)
+}
+
+parse_action <- function(action) {
+  parts <- strsplit(action, "/")[[1]]
+  repo <- sub("[@].*", "", sprintf("%s/%s", parts[1], parts[2]))
+  action_version <- strsplit(parts[length(parts)], "@")[[1]]
+  if (length(parts) > 2) {
+    full <- sprintf("%s/%s", repo, action_version[1])
+  } else {
+    full <- repo
+  }
+
+  ref <- sub("\\s*[#].*$", "", action_version[2])
+  list(full = full, repo = repo, ref = ref)
+}
+

--- a/tests/testthat/test-pin.R
+++ b/tests/testthat/test-pin.R
@@ -38,6 +38,14 @@ test_that("pin_action() works for an individual action", {
   expect_equal(res, expected)
 })
 
+
+test_that("pin_action() will return the latest release", {
+  skip_if_offline()
+  res <- pin_action("r-lib/actions/check-r-package")
+  expect_match(res, "r-lib/actions/check-r-package[@][a-z0-9]{40} [#]v[0-9.]+?")
+})
+
+
 test_that("pin_action_workflow() will update an individual workflow", {
   pin <- "r-lib/actions/check-r-package@14a7e741c1cb130261263aa1593718ba42cf443b #v2.11.2"
   action <- "r-lib/actions/check-r-package@v2.11.2"

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,50 @@
+test_that("SHAs look like SHAs", {
+  make_sha <- function(poison = NULL) {
+    sha_like <- c(letters[1:6], LETTERS[1:6], 0:9)
+    sha <- sample(sha_like, 40, replace = TRUE)
+    if (!is.null(poison)) {
+      sha[sample(40, 1)] <- poison
+    }
+    paste(sha, collapse = "")
+  }
+  expect_true(looks_like_sha(make_sha()))
+  expect_false(looks_like_sha(substring(make_sha(), 1, 39)))
+  expect_false(looks_like_sha(make_sha(poison = "z")))
+  expect_false(looks_like_sha("v32"))
+  expect_false(looks_like_sha("badbadbad"))
+})
+
+
+
+test_that("parse_action can parse an action", {
+  expect_equal(parse_action("JamesIves/github-pages-action@v4.6.1"),
+    list(
+      full = "JamesIves/github-pages-action",
+      repo = "JamesIves/github-pages-action",
+      ref = "v4.6.1"
+    )
+  )
+  expect_equal(parse_action("r-lib/actions/check-r-package@v2"),
+    list(
+      full = "r-lib/actions/check-r-package",
+      repo = "r-lib/actions",
+      ref = "v2"
+    )
+  )
+  expect_equal(parse_action("carpentries/actions/comment-diff@main"),
+    list(
+      full = "carpentries/actions/comment-diff",
+      repo = "carpentries/actions",
+      ref = "main"
+    )
+  )
+  expect_equal(parse_action("carpentries/actions/comment-diff"),
+    list(
+      full = "carpentries/actions/comment-diff",
+      repo = "carpentries/actions",
+      ref = NA_character_
+    )
+  )
+
+})
+


### PR DESCRIPTION
This will allow folks to use `pin_action()` without a tag to get the latest release:

``` r
pinsha::pin_action("docker/login-action")
#> [1] "docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0"
```

<sup>Created on 2025-03-26 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>


Other improvements:

1. move some functions to utils and add tests for them
2. add news