### PR TITLE
 Make pin_action work with annotated tags

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,10 @@
 Package: pinsha
 Title: Pin 'GitHub' Actions to 'SHA'
 Version: 0.0.0.9000
-Authors@R: 
+Authors@R: c(
     person("Zhian N.", "Kamvar", , "zkamvar@gmail.com", role = c("aut", "cre"),
-           comment = c(ORCID = "0000-0003-1458-7108"))
+           comment = c(ORCID = "0000-0003-1458-7108")),
+    person("Becky", "Sweger", , "bsweger@gmail.com", role = c("ctb")))
 Description: Harden your 'GitHub' workflow security by pinning your third-party
     actions to the appropriate 'SHA'. 
 License: MIT + file LICENSE

--- a/man/pinsha-package.Rd
+++ b/man/pinsha-package.Rd
@@ -19,5 +19,10 @@ Useful links:
 \author{
 \strong{Maintainer}: Zhian N. Kamvar \email{zkamvar@gmail.com} (\href{https://orcid.org/0000-0003-1458-7108}{ORCID})
 
+Other contributors:
+\itemize{
+  \item Becky Sweger \email{bsweger@gmail.com} [contributor]
+}
+
 }
 \keyword{internal}

--- a/tests/testthat/test-pin.R
+++ b/tests/testthat/test-pin.R
@@ -45,6 +45,15 @@ test_that("pin_action() will return the latest release", {
   expect_match(res, "r-lib/actions/check-r-package[@][a-z0-9]{40} [#]v[0-9.]+?")
 })
 
+test_that("pin_action() works for an action versioned via an annotated tag", {
+  skip_if_offline()
+  expected <- "nwtgck/actions-netlify@4cbaf4c08f1a7bfa537d6113472ef4424e4eb654 #v3"
+  res <- pin_action("nwtgck/actions-netlify@v3")
+  expect_equal(res, expected)
+
+  # pin action will return early if fed twice:
+  expect_equal(res, pin_action(res))
+})
 
 test_that("pin_action_workflow() will update an individual workflow", {
   pin <- "r-lib/actions/check-r-package@14a7e741c1cb130261263aa1593718ba42cf443b #v2.11.2"


### PR DESCRIPTION
The call to GET /repos/{repo}/git/refs/tags/{tag} "ref" field contains a commit SHA for lightweight tags, which was being used to match a commit SHA in a subsequent call to GET /repos/{repo}/tags

However, for annotated tags, the "ref" in the first result is a tag SHA and will not find a match when searching commit hashes in the second output. For annotated tags, we can match on tag name instead to grab the commit SHA.

-------

To reproduce the original error:

```R
pin_action("nwtgck/actions-netlify@v3.0.0")
```
or 

```R
pin_action("carpentries/actions/comment-diff")
```